### PR TITLE
Potential fix for code scanning alert no. 195: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: reviewdog
 on: [pull_request]
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/Voornaamenachternaam/chachacrypt/security/code-scanning/195](https://github.com/Voornaamenachternaam/chachacrypt/security/code-scanning/195)

To fix the problem, add a `permissions` block to the workflow or the specific job. The minimal required permission for most reviewdog runs is `contents: read` (to read code), and if the action needs to comment on pull requests, `pull-requests: write` should also be included. Since the workflow is triggered on `pull_request` and reviewdog typically posts comments, the best fix is to add:

```yaml
permissions:
  contents: read
  pull-requests: write
```

at the top level of the workflow (after the `name` and before `on`), so it applies to all jobs. Alternatively, it can be added under the `golangci-lint` job, but top-level is preferred for clarity and future jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
