### PR TITLE
Potential fix for code scanning alert no. 194: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   update-go-mod:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Voornaamenachternaam/chachacrypt/security/code-scanning/194](https://github.com/Voornaamenachternaam/chachacrypt/security/code-scanning/194)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the minimal required permissions for the job. In this case, the workflow needs to read repository contents, push changes, and create pull requests. Therefore, set `contents: write` and `pull-requests: write` at the job level (or at the workflow root if all jobs need the same permissions). This should be added just above the `runs-on: ubuntu-latest` line (line 10) in the `update-go-mod` job definition. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
