### PR TITLE
Potential fix for code scanning alert no. 182: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mergeme.yaml
+++ b/.github/workflows/mergeme.yaml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   merge-me:
+    permissions:
+      contents: write
+      pull-requests: write
     name: Merge me!
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Voornaamenachternaam/chachacrypt/security/code-scanning/182](https://github.com/Voornaamenachternaam/chachacrypt/security/code-scanning/182)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. The best practice is to set this at the job level (under `merge-me:`) unless all jobs in the workflow require the same permissions. For a merge action, the minimal permissions are typically `contents: write` (to allow merging code) and possibly `pull-requests: write` (if the action interacts with PRs). The change should be made by inserting the following block under the job definition (after `merge-me:` and before `name:`):

```yaml
permissions:
  contents: write
  pull-requests: write
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
