### PR TITLE
Update Go 1.25.0 and dependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,12 @@
+## [unreleased]
+
+### 🐛 Bug Fixes
+
+- Check and log errors from file Close to pass linter
+
+### ⚙️ Miscellaneous Tasks
+
+- Bump Go to v1.25.0
+- Update Go 1.25 and dependencies
+- Bump Go to v1.25.0
+- Update Go 1.25.0 and dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module chachacrypt
 
-go 1.24.1
+go 1.25.0
 
 require (
-	golang.org/x/crypto v0.36.0
-	golang.org/x/term v0.30.0
+	golang.org/x/crypto v0.41.0
+	golang.org/x/term v0.34.0
 )
 
-require golang.org/x/sys v0.31.0 // indirect
+require golang.org/x/sys v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
-golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
-golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
+golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=
+golang.org/x/crypto v0.41.0/go.mod h1:pO5AFd7FA68rFak7rOAGVuygIISepHftHnr8dr6+sUc=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.34.0 h1:O/2T7POpk0ZZ7MAzMeWFSg6S5IpWd/RXDlM9hgM3DR4=
+golang.org/x/term v0.34.0/go.mod h1:5jC53AEywhIVebHgPVeg0mj8OD3VO9OzclacVrqpaAw=

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,20 @@
+## 🔧 Updates
+- Go version → 1.25.0
+- Dependencies upgraded (safe upgrades only)
+
+## 📜 Changelog Diff
+## [unreleased]
+
+### 🐛 Bug Fixes
+
+- Check and log errors from file Close to pass linter
+
+### ⚙️ Miscellaneous Tasks
+
+- Bump Go to v1.25.0
+- Update Go 1.25 and dependencies
+- Bump Go to v1.25.0
+- Update Go 1.25.0 and dependencies
+
+## ✅ Test Status
+✅ All tests passed


### PR DESCRIPTION
## 🔧 Updates
- Go version → 1.25.0
- Dependencies upgraded (safe upgrades only)

## 📜 Changelog Diff
## [unreleased]

### 🐛 Bug Fixes

- Check and log errors from file Close to pass linter

### ⚙️ Miscellaneous Tasks

- Bump Go to v1.25.0
- Update Go 1.25 and dependencies
- Bump Go to v1.25.0
- Update Go 1.25.0 and dependencies

## ✅ Test Status
✅ All tests passed
