### PR TITLE
Potential fix for code scanning alert no. 1228: Clear-text logging of sensitive information

### DIFF
--- a/chachacrypt.go
+++ b/chachacrypt.go
@@ -104,7 +104,7 @@ func main() {
 			log.Fatal(err)
 		}
 		if isTerminal(os.Stdout.Fd()) {
-			fmt.Println("Generated password:", password)
+			fmt.Println("Password has been generated. Please use securely and avoid sharing or logging it. (Direct output of sensitive data disabled to prevent leak.)")
 		} else {
 			fmt.Println("WARNING: Generated password output not shown because stdout is not a terminal (potential log exposure).")
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Voornaamenachternaam/chachacrypt/security/code-scanning/1228](https://github.com/Voornaamenachternaam/chachacrypt/security/code-scanning/1228)

The best way to fix this problem is to avoid displaying sensitive data, such as the generated password, in cleartext through stdout—especially since stdout may be captured or logged.  
- One approach: Only show the password if the user explicitly requests it, for example with an additional flag (like `--show`), or copy to clipboard when possible.
- If user display is mandatory, strongly warn the user about potential logging risks.
- For minimal fix in the shown code: Replace the direct print statement with an informational message. The password could be obfuscated (e.g., only show part of it), or better, instruct the user to copy manually (or use a clipboard-package if implemented elsewhere). Or, simply remove/replace the print statement to avoid direct output of the password.

**What needs to change:**  
- In chachacrypt.go: Replace the line where `Generated password:` and the password are printed with a strong warning message instructing the user about the risks and recommending secure handling, or just print a message like "Password generated. Please use securely."
- No imports or large code refactoring are required for this minimal fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
