### PR TITLE
fix: resolve compilation errors by using cipher.AEAD interface

### DIFF
--- a/chachacrypt.go
+++ b/chachacrypt.go
@@ -1109,7 +1109,7 @@ func decryptProcess(ctx context.Context, inFile *os.File, outFile *os.File, key 
 	return nil
 }
 
-func decryptChunk(inFile *os.File, aead cipher.AEAD, baseAAD []byte, nonceSize int, seq uint64, header FileHeader) ([]byte, error) {
+func decryptChunk(inFile *os.File, aead cipher.AEAD, baseAAD []byte, seq uint64, header FileHeader) ([]byte, error) {
 	nonce := make([]byte, nonceSize)
 	if _, err := io.ReadFull(inFile, nonce); err == io.EOF {
 		return nil, io.EOF


### PR DESCRIPTION
### **User description**
Co-authored-by: aider (openrouter/tngtech/deepseek-r1t2-chimera:free) <aider@aider.chat>


___

### **PR Type**
Bug fix


___

### **Description**
- Add `crypto/cipher` import for AEAD interface

- Replace concrete `XChaCha20Poly1305` type with `cipher.AEAD` interface

- Update `encryptChunk` function signature to use AEAD interface

- Update `decryptChunk` function signature to use AEAD interface


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Import crypto/cipher"] --> B["Update encryptChunk signature"]
  A --> C["Update decryptChunk signature"]
  B --> D["Use cipher.AEAD interface"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chachacrypt.go</strong><dd><code>Replace concrete cipher type with AEAD interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chachacrypt.go

<ul><li>Added <code>crypto/cipher</code> import to support AEAD interface<br> <li> Changed <code>encryptChunk</code> parameter from <br><code>*chacha20poly1305.XChaCha20Poly1305</code> to <code>cipher.AEAD</code><br> <li> Changed <code>decryptChunk</code> parameter from <br><code>*chacha20poly1305.XChaCha20Poly1305</code> to <code>cipher.AEAD</code><br> <li> Improves code abstraction by depending on interface rather than <br>concrete type</ul>


</details>


  </td>
  <td><a href="https://github.com/Voornaamenachternaam/chachacrypt/pull/182/files#diff-eb7a0dd5bd391f614dc157b7d7673a59c53ea191483636946921b63df20fd286">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

