### PR TITLE
Update chachacrypt.go

### DIFF
--- a/chachacrypt.go
+++ b/chachacrypt.go
@@ -53,7 +53,7 @@ const (
 	maxKeySize     = 1 << 8  // 256 bytes key size upper bound (tightened)
 
 	// CSPRNG validation constants
-	entropyCheckSize = 32  // bytes to sample for entropy check
+	entropyCheckSize = 4096  // bytes to sample for entropy check
 	minEntropyBits   = 7.5 // minimum entropy per byte (NIST SP 800-22)
 
 	// Key rotation constants
@@ -80,27 +80,35 @@ func (r *CSPRNGReader) Read(p []byte) (n int, err error) {
 
 // checkEntropy validates entropy per NIST SP 800-22
 func (r *CSPRNGReader) checkEntropy(sample []byte) error {
-	if len(sample) < entropyCheckSize/2 {
-		return errors.New("insufficient sample size for entropy check")
-	}
+    if len(sample) < entropyCheckSize/2 {
+        return errors.New("insufficient sample size for entropy check")
+    }
 
-	// Calculate Shannon entropy
-	freq := make(map[byte]int)
-	for _, b := range sample {
-		freq[b]++
-	}
+    // Calculate Shannon entropy (empirical / plug-in)
+    freq := make(map[byte]int)
+    for _, b := range sample {
+        freq[b]++
+    }
+    entropy := 0.0
+    for _, count := range freq {
+        p := float64(count) / float64(len(sample))
+        // use math.Log2 for clarity and to avoid relying on an external helper
+        entropy -= p * math.Log2(p)
+    }
 
-	entropy := 0.0
-	for _, count := range freq {
-		p := float64(count) / float64(len(sample))
-		entropy -= p * log2(p)
-	}
+    // maximum empirical entropy possible given sample size:
+    maxPossible := math.Log2(math.Min(256.0, float64(len(sample))))
+    if minEntropyBits > maxPossible {
+        return fmt.Errorf(
+            "sample too small for required entropy: sample=%d, max_possible=%.6f, required=%.6f",
+            len(sample), maxPossible, minEntropyBits,
+        )
+    }
 
-	if entropy < minEntropyBits {
-		return fmt.Errorf("insufficient entropy: %f < %f", entropy, minEntropyBits)
-	}
-
-	return nil
+    if entropy < minEntropyBits {
+        return fmt.Errorf("insufficient entropy: %f < %f", entropy, minEntropyBits)
+    }
+    return nil
 }
 
 // log2 calculates log base 2


### PR DESCRIPTION
### **User description**
1) Replace the constants block

-    entropyCheckSize = 32  // bytes to sample for entropy check
-    minEntropyBits   = 7.5 // minimum entropy per byte (NIST SP 800-22)
+    entropyCheckSize = 4096  // bytes to sample for entropy check (increased)
+    minEntropyBits   = 7.5   // minimum entropy per byte (NIST SP 800-22)

2) Replace the existing checkEntropy function with the new guarded version.

Replace the entire old function (all lines from func (r *CSPRNGReader) checkEntropy(sample []byte) error { down to the matching closing }) with the new function below.

-func (r *CSPRNGReader) checkEntropy(sample []byte) error {
-    if len(sample) < entropyCheckSize/2 {
-        return errors.New("insufficient sample size for entropy check")
-    }
-
-    // Calculate Shannon entropy (empirical / plug-in)
-    freq := make(map[byte]int)
-    for _, b := range sample {
-        freq[b]++
-    }
-    entropy := 0.0
-    for _, count := range freq {
-        p := float64(count) / float64(len(sample))
-        entropy -= p * log2(p)
-    }
-
-    if entropy < minEntropyBits {
-        return fmt.Errorf("insufficient entropy: %f < %f", entropy, minEntropyBits)
-    }
-    return nil
-}
+func (r *CSPRNGReader) checkEntropy(sample []byte) error {
+    if len(sample) < entropyCheckSize/2 {
+        return errors.New("insufficient sample size for entropy check")
+    }
+
+    // Calculate Shannon entropy (empirical / plug-in)
+    freq := make(map[byte]int)
+    for _, b := range sample {
+        freq[b]++
+    }
+    entropy := 0.0
+    for _, count := range freq {
+        p := float64(count) / float64(len(sample))
+        // use math.Log2 for clarity and to avoid relying on an external helper
+        entropy -= p * math.Log2(p)
+    }
+
+    // maximum empirical entropy possible given sample size:
+    maxPossible := math.Log2(math.Min(256.0, float64(len(sample))))
+    if minEntropyBits > maxPossible {
+        return fmt.Errorf(
+            "sample too small for required entropy: sample=%d, max_possible=%.6f, required=%.6f",
+            len(sample), maxPossible, minEntropyBits,
+        )
+    }
+
+    if entropy < minEntropyBits {
+        return fmt.Errorf("insufficient entropy: %f < %f", entropy, minEntropyBits)
+    }
+    return nil
+}


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Increased entropy check sample size from 32 to 4096 bytes

- Replaced custom `log2` helper with standard `math.Log2` function

- Added validation for sample size feasibility against required entropy

- Improved error messages with detailed entropy constraint information


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["entropyCheckSize: 32→4096"] --> B["checkEntropy function"]
  C["Replace log2 helper"] --> B
  D["Add maxPossible validation"] --> B
  B --> E["Improved entropy checks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chachacrypt.go</strong><dd><code>Strengthen entropy validation with larger samples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

chachacrypt.go

<ul><li>Increased <code>entropyCheckSize</code> constant from 32 to 4096 bytes for more <br>robust entropy sampling<br> <li> Replaced custom <code>log2()</code> helper function call with standard <code>math.Log2()</code> <br>for clarity<br> <li> Added validation check to ensure sample size is feasible for required <br>entropy level<br> <li> Enhanced error messages to include sample size, maximum possible <br>entropy, and required entropy values<br> <li> Reformatted function indentation for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/Voornaamenachternaam/chachacrypt/pull/189/files#diff-eb7a0dd5bd391f614dc157b7d7673a59c53ea191483636946921b63df20fd286">+30/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

