### PR TITLE
chore: bump go to 1.26.2
time 2026-03-27T21:58:29Z

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/Voornaamenachternaam/chachacrypt
 
-go 1.26.1
+go 1.26.2
+time 2026-03-27T21:58:29Z
 
 require (
 	golang.org/x/crypto v0.49.0


### PR DESCRIPTION
Automated bump of Go version to 1.26.2
time 2026-03-27T21:58:29Z (AI-assisted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated to the latest stable development toolchain version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->