### PR TITLE
Compute header HMAC after finalizing mutable header fields and add tests

### DIFF
--- a/chachacrypt.go
+++ b/chachacrypt.go
@@ -1506,14 +1506,6 @@ func prepareRotationKeys(
 		return nil, nil, nil, fmt.Errorf("derive keys: %w", err)
 	}
 
-	mac, err := computeHeaderHMAC(&hdr, macKey)
-	if err != nil {
-		secureZero(encKey)
-		secureZero(macKey)
-		return nil, nil, nil, fmt.Errorf("compute header mac: %w", err)
-	}
-	copy(hdr.HeaderMAC[:], mac)
-
 	return &hdr, encKey, macKey, nil
 }
 
@@ -1589,12 +1581,19 @@ func rotateFile(
 	if err != nil {
 		return err
 	}
+	defer secureZero(newEncKey)
+	defer secureZero(newMacKey)
+
 	newHdr.KeyVersion = newKeyVersion
 	newHdr.ChunkSize = origHdr.ChunkSize
 	newHdr.NonceSize = origHdr.NonceSize
 
-	defer secureZero(newEncKey)
-	defer secureZero(newMacKey)
+	// Finalize header MAC only after all mutable header fields are set.
+	newMAC, macErr := computeHeaderHMAC(newHdr, newMacKey)
+	if macErr != nil {
+		return fmt.Errorf("compute new header mac: %w", macErr)
+	}
+	copy(newHdr.HeaderMAC[:], newMAC)
 
 	oldAEAD, err := chacha20poly1305.NewX(oldEncKey)
 	if err != nil {

--- a/chachacrypt_test.go
+++ b/chachacrypt_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestRotationHeaderMACAfterFieldMutation(t *testing.T) {
+	pw := []byte("CorrectHorseBatteryStaple!123")
+	threads := uint8(runtime.NumCPU())
+	if threads > maxThreadLimit {
+		threads = maxThreadLimit
+	}
+	if threads < minArgonThreads {
+		threads = minArgonThreads
+	}
+	hdr, encKey, macKey, err := prepareRotationKeys(pw, defaultArgonTime, defaultArgonMemory, threads)
+	if err != nil {
+		t.Fatalf("prepareRotationKeys failed: %v", err)
+	}
+	defer secureZero(encKey)
+	defer secureZero(macKey)
+
+	// Simulate rotate flow where caller sets fields after key prep.
+	hdr.KeyVersion = 42
+	hdr.ChunkSize = defaultChunkSize
+	hdr.NonceSize = nonceSize
+
+	mac, err := computeHeaderHMAC(hdr, macKey)
+	if err != nil {
+		t.Fatalf("computeHeaderHMAC failed: %v", err)
+	}
+	copy(hdr.HeaderMAC[:], mac)
+
+	expected, err := computeHeaderHMAC(hdr, macKey)
+	if err != nil {
+		t.Fatalf("computeHeaderHMAC second call failed: %v", err)
+	}
+	if !secureCompare(expected, hdr.HeaderMAC[:]) {
+		t.Fatal("header MAC does not match finalized header")
+	}
+}
+
+func TestValidatePathComponentsRejectsParentTraversal(t *testing.T) {
+	if err := validatePathComponents("a/../b"); err == nil {
+		t.Fatal("expected traversal path to be rejected")
+	}
+}
+
+func TestURLPathUnescapeRejectsBadEncoding(t *testing.T) {
+	if _, err := urlPathUnescape("abc%GG"); err == nil {
+		t.Fatal("expected invalid encoding to error")
+	}
+}


### PR DESCRIPTION
### Motivation

- Prevent a stale header HMAC being generated before mutable header fields are set during rotation, which could result in invalid MACs after the caller mutates the header.
- Ensure keys are zeroed and header HMAC is computed only when the header is finalized.

### Description

- Removed premature header MAC computation from `prepareRotationKeys` so the header MAC is not written before caller-set fields are applied.
- Compute the header HMAC in `rotateFile` after setting `KeyVersion`, `ChunkSize`, and `NonceSize`, and copy the resulting MAC into `newHdr.HeaderMAC`.
- Moved `defer secureZero(newEncKey)` and `defer secureZero(newMacKey)` to occur immediately after key creation in `rotateFile` to ensure keys are zeroed on function exit.
- Added `chachacrypt_test.go` with tests `TestRotationHeaderMACAfterFieldMutation`, `TestValidatePathComponentsRejectsParentTraversal`, and `TestURLPathUnescapeRejectsBadEncoding` to assert correct header MAC finalization and path/url validation behavior.

### Testing

- Ran `go test ./...` which executed the new unit tests and existing test suite, and all tests passed.
- The new tests `TestRotationHeaderMACAfterFieldMutation`, `TestValidatePathComponentsRejectsParentTraversal`, and `TestURLPathUnescapeRejectsBadEncoding` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db975f00ac832b80971179656b7fea)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file rotation process to ensure cryptographic authentication is finalized after all header field changes are complete.

* **Tests**
  * Added security validation tests for header authentication, directory traversal prevention, and URL encoding handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->