### PR TITLE
chore: bump go to 1.26.3
time 2026-05-04T20:36:18Z

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/Voornaamenachternaam/chachacrypt
 
-go 1.26.2
+go 1.26.3
+time 2026-05-04T20:36:18Z
 
 require (
 	golang.org/x/crypto v0.50.0


### PR DESCRIPTION
Automated bump of Go version to 1.26.3
time 2026-05-04T20:36:18Z (AI-assisted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development toolchain to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->