### PR TITLE
chore: bump go to 1.26.4
time 2026-05-29T15:26:39Z

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/Voornaamenachternaam/chachacrypt
 
-go 1.26.3
+go 1.26.4
+time 2026-05-29T15:26:39Z
 
 require (
 	golang.org/x/crypto v0.51.0


### PR DESCRIPTION
Automated bump of Go version to 1.26.4
time 2026-05-29T15:26:39Z (AI-assisted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.26.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->