### PR TITLE
chore: bump go to 1.26.5
time 2026-07-01T21:24:27Z

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/Voornaamenachternaam/chachacrypt
 
-go 1.26.4
+go 1.26.5
+time 2026-07-01T21:24:27Z
 
 require (
 	golang.org/x/crypto v0.53.0


### PR DESCRIPTION
Automated bump of Go version to 1.26.5
time 2026-07-01T21:24:27Z (AI-assisted).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Voornaamenachternaam/chachacrypt/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version.
  * Refreshed associated build metadata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->